### PR TITLE
Support standard AWS key access by removing the local aws.json requirement

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var async = require('async');
 var moment = require('moment');
 
 var AWS = require('aws-sdk');
-AWS.config.loadFromPath('./aws.json');
 var s3 = new AWS.S3();
 
 var formats = require('./formats');


### PR DESCRIPTION
Removing the explicit load from a local file called `aws.json` allows
the default behavior of the aws-sdk node package to be used, one of
which is to access aws environment variables or from your ~/.aws/config
file.